### PR TITLE
Support IPv6 addresses in netstat output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pol lets you do awk-like one liners in python.
 
 For example, the following will graph the number of connections for each hosts.
 ```bash
-$ netstat -an | pol "map(print,['{}\t{}'.format(i['e'],'*' * i['c']) for i in sortedbycount([l[4].split(':')[0] for l in _ if len(l)>5 and l[5]=='ESTABLISHED'],True)])"
+$ netstat -an | pol "map(print,['{}\t{}'.format(i['e'],'*' * i['c']) for i in sortedbycount([l[4].rsplit(':', 1)[0] for l in _ if len(l)>5 and l[5]=='ESTABLISHED'],True)])"
 ```
 
 Example output:

--- a/hall_of_fame.md
+++ b/hall_of_fame.md
@@ -7,7 +7,7 @@ Please submit a PR with your one-liner to add it to the Hall of Fame.
 #### Graph the number of connections for IP address for your box, and to whom the IP address belongs to
 
 ```bash
-netstat -an | pol "map(print,['{}\t{:25.25}\t{}'.format(i['e'],get([' '.join(l[1:]) for l in sh('whois %s'%i['e']) if len(l)>0 and 'OrgName' in l[0]],0),'*' * i['c']) for i in sortedbycount([l[4].split(':')[0] for l in _ if len(l)>5 and l[5]=='ESTABLISHED'],True)[:10]])"
+netstat -an | pol "map(print,['{}\t{:25.25}\t{}'.format(i['e'],get([' '.join(l[1:]) for l in sh('whois %s'%i['e']) if len(l)>0 and 'OrgName' in l[0]],0),'*' * i['c']) for i in sortedbycount([l[4].rsplit(':', 1)[0] for l in _ if len(l)>5 and l[5]=='ESTABLISHED'],True)[:10]])"
 ```
 
 Example output


### PR DESCRIPTION
IPv4 is a legacy protocol, I don't see why we shouldn't support IPv6 addresses in our one liners. ;-)